### PR TITLE
fix: use Node.js for healthcheck instead of wget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,9 +83,9 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
-# Healthcheck
+# Healthcheck (utilise Node.js car wget n'est pas dans alpine)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:3000/ || exit 1
+    CMD node -e "fetch('http://localhost:3000/').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 
 # Démarrer l'application
 CMD ["node", "server.js"]


### PR DESCRIPTION
wget is not available in node:alpine image, causing the container to restart in a loop.