### PR TITLE
feat: add CSP headers for Google Analytics and reCAPTCHA

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -33,76 +33,51 @@ const nextConfig: NextConfig = {
     removeConsole: process.env.NODE_ENV === 'production',
   },
   
-  // Headers de sécurité et performance - désactivés pour l'export statique
-  // Les headers seront configurés au niveau du serveur web (nginx)
-  // async headers() {
-  //   return [
-  //     {
-  //       source: '/(.*)',
-  //       headers: [
-  //         {
-  //           key: 'X-Content-Type-Options',
-  //           value: 'nosniff',
-  //         },
-  //         {
-  //           key: 'X-Frame-Options',
-  //           value: 'DENY',
-  //         },
-  //         {
-  //           key: 'X-XSS-Protection',
-  //           value: '1; mode=block',
-  //         },
-  //         {
-  //           key: 'Referrer-Policy',
-  //           value: 'strict-origin-when-cross-origin',
-  //         },
-  //         {
-  //           key: 'Permissions-Policy',
-  //           value: 'camera=(), microphone=(), geolocation=()',
-  //         },
-  //         {
-  //           key: 'Strict-Transport-Security',
-  //           value: 'max-age=31536000; includeSubDomains; preload',
-  //         },
-  //       ],
-  //     },
-  //     {
-  //       source: '/sitemap.xml',
-  //       headers: [
-  //         {
-  //           key: 'Content-Type',
-  //           value: 'application/xml',
-  //         },
-  //         {
-  //           key: 'Cache-Control',
-  //           value: 'public, max-age=86400, s-maxage=86400',
-  //         },
-  //       ],
-  //     },
-  //     {
-  //       source: '/robots.txt',
-  //       headers: [
-  //         {
-  //           key: 'Content-Type',
-  //           value: 'text/plain',
-  //         },
-  //         {
-  //           key: 'Cache-Control',
-  //           value: 'public, max-age=86400, s-maxage=86400',
-  //         },
-  //       ],
-  //     },
-  //     {
-  //       source: '/static/:path*',
-  //       headers: [
-  //         {
-  //           key: 'Cache-Control',
-  //           value: 'public, max-age=31536000, immutable',
-  //         },
-  //       ],
-  //     },
-  //   ];
-  // },
+  // Headers de sécurité et performance
+  async headers() {
+    // CSP pour Google Analytics, reCAPTCHA et autres services Google
+    const csp = [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.gstatic.com https://www.googletagmanager.com",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: https: blob:",
+      "font-src 'self'",
+      "frame-src https://www.google.com",
+      "connect-src 'self' https://www.google.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com",
+    ].join('; ');
+
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: csp,
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'X-XSS-Protection',
+            value: '1; mode=block',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Configure Content-Security-Policy in Next.js to allow:
- Google Analytics (including regional subdomains)
- Google reCAPTCHA
- Google Tag Manager