### PR TITLE
security: add HSTS header and replace unsafe CSP directives with nonces

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -33,46 +33,21 @@ const nextConfig: NextConfig = {
     removeConsole: process.env.NODE_ENV === 'production' ? { exclude: ['error'] } : false,
   },
   
-  // Headers de sécurité et performance
+  // Headers de sécurité pour les assets statiques
+  // Note: Le CSP principal est géré par le middleware avec nonces dynamiques
   async headers() {
-    // CSP pour Google Analytics, reCAPTCHA et autres services Google
-    const csp = [
-      "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.gstatic.com https://www.googletagmanager.com",
-      "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: https: blob:",
-      "font-src 'self'",
-      "frame-src https://www.google.com",
-      "connect-src 'self' https://www.google.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com",
-    ].join('; ');
-
     return [
       {
-        source: '/(.*)',
+        // Headers pour les fichiers statiques (non gérés par le middleware)
+        source: '/:path*.(ico|png|jpg|jpeg|gif|svg|webp|woff|woff2|ttf|eot)',
         headers: [
-          {
-            key: 'Content-Security-Policy',
-            value: csp,
-          },
           {
             key: 'X-Content-Type-Options',
             value: 'nosniff',
           },
           {
-            key: 'X-Frame-Options',
-            value: 'DENY',
-          },
-          {
-            key: 'X-XSS-Protection',
-            value: '1; mode=block',
-          },
-          {
-            key: 'Referrer-Policy',
-            value: 'strict-origin-when-cross-origin',
-          },
-          {
-            key: 'Permissions-Policy',
-            value: 'camera=(), microphone=(), geolocation=()',
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
           },
         ],
       },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import StructuredData from "@/components/StructuredData";
 import Script from "next/script";
+import { headers } from "next/headers";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -88,22 +89,26 @@ export const metadata: Metadata = {
   category: "technology",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const headersList = await headers();
+  const nonce = headersList.get('x-nonce') ?? undefined;
+
   return (
     <html lang="fr">
       <head>
         <StructuredData />
-        
+
         {/* Google Analytics */}
         <Script
           src="https://www.googletagmanager.com/gtag/js?id=G-631LMS44B0"
           strategy="afterInteractive"
+          nonce={nonce}
         />
-        <Script id="ga-setup" strategy="afterInteractive">
+        <Script id="ga-setup" strategy="afterInteractive" nonce={nonce}>
           {`
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function proxy(request: NextRequest) {
+  // Générer un nonce unique pour cette requête
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
+  const isDev = process.env.NODE_ENV === 'development';
+
+  // Construire le CSP avec le nonce
+  // En dev, on ajoute unsafe-eval pour le hot reload
+  const cspHeader = `
+    default-src 'self';
+    script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https://www.google.com https://www.gstatic.com https://www.googletagmanager.com ${isDev ? "'unsafe-eval'" : ''};
+    style-src 'self' ${isDev ? "'unsafe-inline'" : `'nonce-${nonce}'`};
+    img-src 'self' data: https: blob:;
+    font-src 'self';
+    frame-src https://www.google.com;
+    connect-src 'self' https://www.google.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com ${isDev ? 'ws://localhost:* http://localhost:*' : ''};
+    base-uri 'self';
+    form-action 'self';
+    frame-ancestors 'none';
+    upgrade-insecure-requests;
+  `.replace(/\s{2,}/g, ' ').trim();
+
+  // Cloner les headers de la requête
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+  requestHeaders.set('Content-Security-Policy', cspHeader);
+
+  // Créer la réponse avec les headers de sécurité
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+
+  // Ajouter les headers de sécurité
+  response.headers.set('Content-Security-Policy', cspHeader);
+  response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload');
+  response.headers.set('X-Content-Type-Options', 'nosniff');
+  response.headers.set('X-Frame-Options', 'DENY');
+  response.headers.set('X-XSS-Protection', '1; mode=block');
+  response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+
+  return response;
+}


### PR DESCRIPTION
- Add Strict-Transport-Security header (max-age=31536000; includeSubDomains; preload)
- Replace 'unsafe-inline' and 'unsafe-eval' in CSP with dynamic nonces
- Migrate from deprecated middleware.ts to proxy.ts (Next.js 16 convention)
- Add nonce support to Google Analytics scripts in layout.tsx